### PR TITLE
tccc scrapy export utf-8 json file and prettyjson.py

### DIFF
--- a/crawler/tccc/tccc/pipelines.py
+++ b/crawler/tccc/tccc/pipelines.py
@@ -3,51 +3,11 @@
 # Don't forget to add your pipeline to the ITEM_PIPELINES setting
 # See: http://doc.scrapy.org/en/latest/topics/item-pipeline.html
 import json
-from scrapy.contrib.exporter import BaseItemExporter, JsonLinesItemExporter, JsonItemExporter
-
 
 class TccPipeline(object):
     def process_item(self, item, spider):
         return item
 
 
-def encode_list(data):
-    rv = []
-    for item in data:
-        if isinstance(item, unicode):
-            item = item.encode('utf-8')
-        elif isinstance(item, list):
-            item = encode_list(item)
-        elif isinstance(item, dict):
-            item = encode_dict(item)
-        rv.append(item)
-    return rv
 
 
-def encode_dict(data):
-    rv = {}
-    for key, value in data.iteritems():
-        if isinstance(key, unicode):
-            key = key.encode('utf-8')
-        if isinstance(value, unicode):
-            value = value.encode('utf-8')
-        elif isinstance(value, list):
-            value = encode_list(value)
-        elif isinstance(value, dict):
-            value = encode_dict(value)
-        rv[key] = value
-    return rv
-
-
-class UnicodeJsonItemExporter(JsonItemExporter):
-    def __init__(self, file, **kwargs):
-        JsonItemExporter.__init__(self, file, ensure_ascii=False, **kwargs)
-
-    def export_item(self, item):
-        if self.first_item:
-            self.first_item = False
-        else:
-            self.file.write(',\n')
-        itemdict = dict(self._get_serialized_fields(item))
-        itemdict = encode_dict(itemdict)
-        self.file.write(self.encoder.encode(itemdict))

--- a/crawler/tccc/tccc/settings.py
+++ b/crawler/tccc/tccc/settings.py
@@ -5,6 +5,11 @@
 #
 #     http://doc.scrapy.org/en/latest/topics/settings.html
 #
+import os,sys
+from os.path import dirname
+# add python path for crawler_lib
+_PROJECT_PATH = dirname(dirname(dirname(dirname(__file__))))
+sys.path.append(os.path.join(_PROJECT_PATH, 'crawler'))
 
 BOT_NAME = 'tccc'
 
@@ -12,9 +17,9 @@ SPIDER_MODULES = ['tccc.spiders']
 NEWSPIDER_MODULE = 'tccc.spiders'
 LOG_FILE = 'log.txt'
 
-#FEED_EXPORTERS = {
-#    'json': 'tccc.pipelines.UnicodeJsonItemExporter',
-#}
+FEED_EXPORTERS = {
+    'json': 'crawler_lib.misc.UnicodeJsonItemExporter',
+}
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 #USER_AGENT = 'taipei (+http://www.yourdomain.com)'

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,22 @@
+
+## prettyjson.py
+
+print the pretty json stdout
+
+```
+$ cd crawler/tccc
+$ scrapy crawl councilors -o /tmp/test.json
+$ python ../../utils/prettyjson.py /tmp/test.json
+```
+
+print the item[3] pretty json stdout
+
+```
+$ python ../../utils/prettyjson.py /tmp/test.json 3
+```
+
+save the pretty json file
+
+```
+$ python ../../utils/prettyjson.py /tmp/test.json /tmp/pretty.json
+```

--- a/utils/prettyjson.py
+++ b/utils/prettyjson.py
@@ -1,0 +1,53 @@
+r"""Command-line tool to validate and pretty-print JSON
+
+Usage::
+    $ cd crawler/tccc
+    $ scrapy crawl councilors -o /tmp/test.json
+    # save to file
+    $ python ../../utils/prettyjson.py /tmp/test.json /tmp/pretty.json
+    # print to sdtout
+    $ python ../../utils/prettyjson.py /tmp/test.json
+    # print item[3] by indext
+    $ python ../../utils/prettyjson.py /tmp/test.json 3
+    
+"""
+import sys
+import json
+import io
+
+def is_int(s):
+    try: 
+        int(s)
+        return True
+    except ValueError:
+        return False
+
+def main():
+    index = -1
+    if len(sys.argv) == 1:
+        infile = sys.stdin
+        outfile = sys.stdout
+    elif len(sys.argv) == 2:
+        infile = open(sys.argv[1], 'rb')
+        outfile = sys.stdout
+    elif len(sys.argv) == 3:
+        infile = open(sys.argv[1], 'rb')
+        if is_int(sys.argv[2]):
+            index = int(sys.argv[2])
+            outfile = sys.stdout
+        else:
+            outfile = io.open(sys.argv[2], 'w', encoding='utf8')
+    else:
+        raise SystemExit("{0} [infile [outfile/itemindex]]".format(sys.argv[0]))
+    try:
+        obj = json.load(infile)
+        if index >=0 :
+            obj = obj[index]
+    except ValueError, e:
+        raise SystemExit(e)
+    jd = json.dumps(obj, indent=4, sort_keys=True, ensure_ascii=False, encoding='utf8')
+    outfile.write(jd)
+    outfile.write(u'\n')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
fix #9 

changelog
- move UnicodeJsonItemExporter to crawler_lib.misc
- add utils/prettyjson.py
- only tccc

example 

```
$ cd crawler/tccc
$ scrapy crawl councilors -o /tmp/test.json
$ python ../../utils/prettyjson.py /tmp/test.json 2
{
    "constituency": "第04選區",
    "contact_details": [
        {
            "label": "服務處地址",
................
    "term_end": {
        "date": "2014-12-25"
    },
    "term_start": "2010-12-25",
    "title": "議員"
}
```
