### PR TITLE
 #25. fix bug. the foregin key, proposer, in Bills point to councilors.C...

### DIFF
--- a/voter_guide/bills/views.py
+++ b/voter_guide/bills/views.py
@@ -3,7 +3,7 @@ import operator
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.db.models import Count, Q
-from .models import Bills, Councilors_Bills
+from .models import Bills
 from councilors.models import CouncilorsDetail
 from search.models import Keyword
 from search.views import keyword_list, keyword_been_searched, keyword_normalize


### PR DESCRIPTION
我沒注意到 Bills.proposer 是指向 CouncilorsDetail.id 而非  CouncilorsDetail.councilor.id。
導致只有台北市能夠正常依據地區搜索結果

之前會正確大概是台北市很多人的 CouncilorsDetail.councilor.id 和 CouncilorsDetail.id 相等
