### PR TITLE
修正 "打勾:不是第一提案人也計數" 的顯示方式

### DIFF
--- a/voter_guide/templates/councilors/index/index_ordered.html
+++ b/voter_guide/templates/councilors/index/index_ordered.html
@@ -26,7 +26,7 @@
             <form action="" method="get" class="form-inline text-center" id="form_bill">
                 <fieldset>
                     <label class="checkbox">
-                        <input type="checkbox" name="proposertype" id="proposertype" {% if proposertype %} checked{% endif %} rel="tooltip" title="打勾:不是第一提案人也計數">
+                      <input type="checkbox" name="proposertype" id="proposertype" {% if proposertype %} checked{% endif %} rel="tooltip">"打勾:不是第一提案人也計數"
                     </label>
                 </fieldset>
             </form>


### PR DESCRIPTION
把 
![2014-11-19 12 01 42](https://cloud.githubusercontent.com/assets/5138409/5100604/ffa483bc-6fe3-11e4-80e4-346caf3b498f.png)
變成

![2014-11-19 11 58 33](https://cloud.githubusercontent.com/assets/5138409/5100602/f58412ee-6fe3-11e4-9361-a574f8a0c8ba.png)
