### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Now you should able to see the web page at http://localhost:8000
 
 ## Mac Related Instructions
 
-###Prepare Compiler
+### Prepare Compiler
 
 There are some python package written in C or C++ such as lxml. so a compiler is required. you can install a compiler via the following command:
 
@@ -129,7 +129,7 @@ xcode-select --install
 
 
 
-###Prepare PostgreSQL
+### Prepare PostgreSQL
 
 You can install the packaged app [here](http://postgresapp.com).
 put the app in your Application folder and click it to start. 

--- a/utils/README.md
+++ b/utils/README.md
@@ -19,4 +19,4 @@ save the pretty json file
 
 ```
 $ python ../../utils/prettyjson.py /tmp/test.json /tmp/pretty.json
-```
+``

--- a/utils/bin-hash/README.md
+++ b/utils/bin-hash/README.md
@@ -15,4 +15,4 @@ Test
 ```
 $ cd utils/bin-hash
 $ nosetests
-```
+``


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
